### PR TITLE
Fix GPU OOM errors upon evaluation

### DIFF
--- a/lrtc_lib/train_and_infer_service/train_and_infer_hf.py
+++ b/lrtc_lib/train_and_infer_service/train_and_infer_hf.py
@@ -166,14 +166,19 @@ class TrainAndInferHF(TrainAndInferAPI):
 
         input = self.process_inputs(items_to_infer).batch(self.infer_batch_size)
         if self.infer_with_cls:  # get embeddings for CLS token in last hidden layer
+            outputs = {"hidden_states":[],"logits":[]}
+            for inp in input:
+                output = model(inp[0])
+                outputs["logits"].append(output[0])
+                outputs["hidden_states"].append(output[1])
             outputs = [model(inp[0]) for inp in input]
-            logits = tf.concat([output[0] for output in outputs], axis=0)
-            hidden_states = tf.concat([output[1] for output in outputs], axis=1)
+            logits = tf.concat(outputs["logits"], axis=0)
+            hidden_states = tf.concat(outputs["hidden_states"], axis=1)
             embeddings = hidden_states[-1]  # 0=embedding x=embedding at layer x, only last layer is interesting
             out_emb = embeddings[:, 0, :]
         else:  # get embeddings from pooled output, following the logic of TFBertForSequenceClassification "call" func
-            outputs = [model.bert(inp[0]) for inp in input]
-            out_emb = tf.concat([output[1] for output in outputs], axis=0)
+            outputs = [model.bert(inp[0])[1] for inp in input]
+            out_emb = tf.concat(outputs, axis=0)
             pooled_output = model.dropout(out_emb, training=False)
             logits = model.classifier(pooled_output)
         labels = [int(np.argmax(logit)) for logit in logits]

--- a/lrtc_lib/train_and_infer_service/train_and_infer_hf.py
+++ b/lrtc_lib/train_and_infer_service/train_and_infer_hf.py
@@ -171,7 +171,6 @@ class TrainAndInferHF(TrainAndInferAPI):
                 output = model(inp[0])
                 outputs["logits"].append(output[0])
                 outputs["hidden_states"].append(output[1])
-            outputs = [model(inp[0]) for inp in input]
             logits = tf.concat(outputs["logits"], axis=0)
             hidden_states = tf.concat(outputs["hidden_states"], axis=1)
             embeddings = hidden_states[-1]  # 0=embedding x=embedding at layer x, only last layer is interesting


### PR DESCRIPTION
I was getting an OOM error with larger datasets even with a smaller batch size and model (base with batch 10): 
`tensorflow.python.framework.errors_impl.ResourceExhaustedError: OOM when allocating tensor with shape[10,100,3072] and type float on /job:localhost/replica:0/task:0/device:GPU:0 by allocator GPU_0_bfc [Op:Erf]`
The lines that were causing it are those changed in the commit. I found that keeping a list of the model calls was using uneccessary memory during evaluation and it works after this change.
(Also I would like to add that I really appreciate how organised and well documented this repository is!)